### PR TITLE
fix typo?

### DIFF
--- a/ROScheatsheet.tex
+++ b/ROScheatsheet.tex
@@ -534,7 +534,7 @@ Get a local copy of the code for an existing package and keep it up to date usin
 E\=x\=amples:\\
 \>\texttt{\$ cd \textasciitilde/catkin\_ws/src}\\
 \>\texttt{\$ wstool init}\\
-\>\texttt{\$ wstool set tut --git git://github.com/ros/ros\_tutorials.git}\\
+\>\texttt{\$ wstool set --git git://github.com/ros/ros\_tutorials.git}\\
 \>\texttt{\$ wstool update}\\
 \end{nstabbing}
 \vspace{-3mm}


### PR DESCRIPTION
fix from
`git set tut --git ....`

to
`git set --git ....`

But not confident....